### PR TITLE
Collect CPU and RAM for VMs and Hosts

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -32,9 +32,9 @@ class Cfme::CloudServices::DataCollector
       "api_version"   => nil,
       "name"          => nil,
       "type"          => nil,
-      "vms"           => ["id", "ems_ref", "name", "type"],
-      "miq_templates" => ["id", "ems_ref", "name", "type"],
-      "hosts"         => ["id", "ems_ref", "name", "type"]
+      "vms"           => ["id", "cpu_total_cores", "ems_ref", "name", "type", "ram_size"],
+      "miq_templates" => ["id", "cpu_total_cores", "ems_ref", "name", "type", "ram_size"],
+      "hosts"         => ["id", "cpu_total_cores", "ems_ref", "name", "type", "ram_size"]
     }
 
     {


### PR DESCRIPTION
Collect CPUs and RAM size for VMs and Hosts for [vm.cpus](https://github.com/ManageIQ/topological_inventory-ingress_api/blob/master/public/doc/openapi-3-v0.0.2.json#L2849-L2852), [vm.memory](https://github.com/ManageIQ/topological_inventory-ingress_api/blob/master/public/doc/openapi-3-v0.0.2.json#L2892-L2895), [host.cpus](https://github.com/ManageIQ/topological_inventory-ingress_api/blob/master/public/doc/openapi-3-v0.0.2.json#L1137-L1140), and [host.memory](https://github.com/ManageIQ/topological_inventory-ingress_api/blob/master/public/doc/openapi-3-v0.0.2.json#L1153-L1156) on the topology size.

```
"vms": [
{
  "id": 43,
  "name": "billy_5_10_4_2",
  "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
  "ems_ref": "vm-301",
  "ram_size": 12288,
  "cpu_total_cores": 4
}
```

```
"hosts": [
{
  "id": 3,
  "name": "dell-r430-05.example.com",
  "type": "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
  "ems_ref": "host-117",
  "cpu_total_cores": 20,
  "ram_size": 130850
},
```