### PR TITLE
Add GUID to provider for source uid

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -30,6 +30,7 @@ class Cfme::CloudServices::DataCollector
     common = {
       "id"            => nil,
       "api_version"   => nil,
+      "guid"          => nil,
       "name"          => nil,
       "type"          => nil,
       "vms"           => ["id", "ems_ref", "name", "type"],


### PR DESCRIPTION
Collect the provider record GUID to be used for the main [`source.uid`](https://github.com/ManageIQ/topological_inventory-ingress_api/blob/master/public/doc/openapi-3-v0.0.2.json#L1255-L1257) which will be created on first upload.

```
"ManageIQ::Providers::Vmware::InfraManager": {
  "id": 1,
  "api_version": "6.7.1",
  "guid": "4a231bbe-1861-408e-ac05-1a2a5e06c29a",
   "name": "dev-vc67",
  "type": "ManageIQ::Providers::Vmware::InfraManager",
}
```