### PR TITLE
Add method for inventory upload to insights uploader

### DIFF
--- a/cfme-cloud_services.gemspec
+++ b/cfme-cloud_services.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "json-stream", "~> 0.2.0"
 end

--- a/lib/cfme/cloud_services/payload_builder.rb
+++ b/lib/cfme/cloud_services/payload_builder.rb
@@ -1,0 +1,30 @@
+module Cfme
+  module CloudServices
+    module PayloadBuilder
+      INVENTORY_FILE_NAME = "cfme_inventory".freeze
+
+      def gzipped_tar_file_from(payload)
+        require 'rubygems/package'
+        begin
+          packed_file = Tempfile.new(INVENTORY_FILE_NAME)
+          packed_file_path = packed_file.path
+
+          File.open(packed_file_path, "wb") do |file|
+            Zlib::GzipWriter.wrap(file) do |gz|
+              Gem::Package::TarWriter.new(gz) do |tar|
+                json_content = payload
+                tar.add_file_simple(INVENTORY_FILE_NAME, 0o0444, json_content.length) do |io|
+                  io.write(json_content)
+                end
+              end
+            end
+          end
+          packed_file&.close
+          yield(packed_file_path)
+        ensure
+          packed_file&.unlink
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- inventory is collected to json file
- this json file is packed to `tar.gz`
- `insights-client` is used for sending to cloud

**How to test it**
(if you have ManageIQ::Providers::Vmware::InfraManager provider):

```ruby
target = ManageIQ::Providers::Vmware::InfraManager.first
Cfme::CloudServices::DataCollector.collect(target)
```

