### PR TITLE
Add ems_extensions and ems_licenses to payload

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -112,7 +112,25 @@ class Cfme::CloudServices::DataCollector
         },
         "ManageIQ::Providers::OpenStack::CloudManager" => common.clone,
         "ManageIQ::Providers::Redhat::InfraManager"    => common.clone,
-        "ManageIQ::Providers::Vmware::InfraManager"    => common.clone,
+        "ManageIQ::Providers::Vmware::InfraManager"    => common.clone.merge(
+          "ems_extensions" => {
+            "id"      => nil,
+            "ems_ref" => nil,
+            "key"     => nil,
+            "company" => nil,
+            "label"   => nil,
+            "summary" => nil,
+            "version" => nil
+          },
+          "ems_licenses"   => {
+            "id"              => nil,
+            "ems_ref"         => nil,
+            "name"            => nil,
+            "license_edition" => nil,
+            "total_licenses"  => nil,
+            "used_licenses"   => nil,
+          },
+        ),
       }
     }.to_json
   end


### PR DESCRIPTION
Extensions:
```
"ems_extensions": [
{
  "id": 1,
  "ems_ref": "com.vmware.vim.sms",
  "key": "com.vmware.vim.sms",
  "company": "VMware Inc.",
  "label": "VMware vCenter Storage Monitoring Service",
  "summary": "Storage Monitoring and Reporting",
  "version": "6.7.0"
}
```

Licenses:
```
"ems_licenses": [
{
  "id": 1,
  "ems_ref": "00000-00000-00000-00000-00000",
  "name": "VMware vCenter Server 6 Standard",
  "license_key": "00000-00000-00000-00000-00000",
  "license_edition": "vc.standard.instance",
  "total_licenses": 6,
  "used_licenses": 1
},
```