### PR TITLE
Allow for multiple providers per provider type

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -145,7 +145,7 @@ class Cfme::CloudServices::DataCollector
 
     object  = scope_with_includes(manifest, target.class).find_by(:id => target.id)
     content = extract_data(object, manifest)
-    {target.class.name => content}
+    {target.class.name => [content]}
   end
 
   def scope_with_includes(manifest, klass)

--- a/spec/data_collector_spec.rb
+++ b/spec/data_collector_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Cfme::CloudServices::DataCollector do
 
       processed = described_class.new(ems).send(:process, parsed_manifest)
       expect(processed.keys).to eq [ems.class.name]
-      processed = processed[ems.class.name]
+      processed = processed[ems.class.name].first
 
       expect(processed.keys).to match_array ["id", "name", "vms", "hosts"]
       expect(processed).to include(


### PR DESCRIPTION
Allow for the future possibility of having multiple providers per
provider type by using an array for each ems_type.