### PR TITLE
Add some metadata about the payload

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -145,7 +145,7 @@ class Cfme::CloudServices::DataCollector
 
     object  = scope_with_includes(manifest, target.class).find_by(:id => target.id)
     content = extract_data(object, manifest)
-    {target.class.name => content}
+    {target.class.name => [content]}
   end
 
   def scope_with_includes(manifest, klass)

--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -96,7 +96,6 @@ class Cfme::CloudServices::DataCollector
     }
 
     {
-      "cfme_version" => cfme_version,
       "manifest" => {
         "core" => {
           "MiqDatabase" => {
@@ -118,7 +117,7 @@ class Cfme::CloudServices::DataCollector
   end
 
   def process(manifest)
-    case target
+    payload = case target
     when "core"
       process_core(manifest)
     when ExtManagementSystem
@@ -126,6 +125,11 @@ class Cfme::CloudServices::DataCollector
     else
       raise "Unknown target: #{target.inspect}"
     end
+
+    {
+      "schema"       => {"name" => "cfme"},
+      "cfme_version" => cfme_version,
+    }.merge(payload)
   end
 
   def process_core(manifest)

--- a/spec/data_collector_spec.rb
+++ b/spec/data_collector_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Cfme::CloudServices::DataCollector do
 
       processed = described_class.new(ems).send(:process, parsed_manifest)
       expect(processed.keys).to eq [ems.class.name]
-      processed = processed[ems.class.name]
+      processed = processed[ems.class.name].first
 
       expect(processed.keys).to match_array ["id", "name", "vms", "hosts"]
       expect(processed).to include(

--- a/spec/data_collector_spec.rb
+++ b/spec/data_collector_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Cfme::CloudServices::DataCollector do
       ems = ManageIQ::Providers::Vmware::InfraManager.first
 
       processed = described_class.new(ems).send(:process, parsed_manifest)
-      expect(processed.keys).to eq [ems.class.name]
+      expect(processed.keys).to include(ems.class.name)
       processed = processed[ems.class.name].first
 
       expect(processed.keys).to match_array ["id", "name", "vms", "hosts"]
@@ -46,7 +46,7 @@ RSpec.describe Cfme::CloudServices::DataCollector do
 
     it "with the core target" do
       processed = described_class.new("core").send(:process, parsed_manifest)
-      expect(processed.keys).to eq ["core"]
+      expect(processed.keys).to include("core")
       processed = processed["core"]
 
       expect(processed.keys).to match_array ["Zone"]


### PR DESCRIPTION
Include the schema type of cfme and the cfme_version in the payload that is
uploaded to assist in identifying the type of payload without having to
which other keys are present.

Depends on: https://github.com/RedHatCloudForms/cfme-cloud_services/pull/14