### PR TITLE
Add Hosts, EmsClusters, and Storages to manifest

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -95,6 +95,52 @@ class Cfme::CloudServices::DataCollector
       }
     }
 
+    infra_common = {
+      "ems_clusters" => {
+        "id"               => nil,
+        "uid_ems"          => nil,
+        "ems_ref"          => nil,
+        "ha_enabled"       => nil,
+        "drs_enabled"      => nil,
+        "effective_cpu"    => nil,
+        "effective_memory" => nil,
+      },
+      "hosts"        => {
+        "id"                   => nil,
+        "name"                 => nil,
+        "type"                 => nil,
+        "hostname"             => nil,
+        "ipaddress"            => nil,
+        "power_state"          => nil,
+        "guid"                 => nil,
+        "uid_ems"              => nil,
+        "mac_address"          => nil,
+        "maintenance"          => nil,
+        "vmm_vendor"           => nil,
+        "vmm_version"          => nil,
+        "vmm_product"          => nil,
+        "vmm_buildnumber"      => nil,
+        "archived"             => nil,
+        "cpu_cores_per_socket" => nil,
+        "cpu_total_cores"      => nil,
+        "ems_cluster_id"       => nil,
+      },
+      "storages" => {
+        "id"                  => nil,
+        "name"                => nil,
+        "location"            => nil,
+        "store_type"          => nil,
+        "total_space"         => nil,
+        "free_space"          => nil,
+        "uncommitted"         => nil,
+        "storage_domain_type" => nil,
+        "host_storages"       => {
+          "ems_ref" => nil,
+          "host_id" => nil,
+        }
+      }
+    }
+
     {
       "cfme_version" => cfme_version,
       "manifest" => {
@@ -111,7 +157,9 @@ class Cfme::CloudServices::DataCollector
           }
         },
         "ManageIQ::Providers::OpenStack::CloudManager" => common.clone,
-        "ManageIQ::Providers::Redhat::InfraManager"    => common.clone,
+        "ManageIQ::Providers::Redhat::InfraManager"    => common.clone.merge(
+          infra_common
+        ),
         "ManageIQ::Providers::Vmware::InfraManager"    => common.clone.merge(
           "ems_extensions" => {
             "id"      => nil,
@@ -130,6 +178,8 @@ class Cfme::CloudServices::DataCollector
             "total_licenses"  => nil,
             "used_licenses"   => nil,
           },
+        ).merge(
+          infra_common
         ),
       }
     }.to_json


### PR DESCRIPTION
EmsCluster:
```
{
 "id"=>1,
 "uid_ems"=>"domain-c109",
 "ems_ref"=>"domain-c109",
 "ha_enabled"=>false,
 "drs_enabled"=>true,
 "effective_cpu"=>122271,
 "effective_memory"=>387353411584
 }
 ```

Hosts:
 ```
 {
 "id"=>3,
 "name"=>"dell-r430-21",
 "type"=>"ManageIQ::Providers::Vmware::InfraManager::HostEsx",
 "hostname"=>"dell-r430-21",
 "ipaddress"=>"1.2.3.4",
 "power_state"=>"on",
 "guid"=>"81ed14c3-968d-4f33-952f-c507b9c721a3",
 "uid_ems"=>"dell-r430-21",
 "mac_address"=>nil,
 "maintenance"=>false,
 "vmm_vendor"=>"vmware",
 "vmm_version"=>"6.7.0",
 "vmm_product"=>"ESXi",
 "vmm_buildnumber"=>"8169922",
 "archived"=>false,
 "cpu_cores_per_socket"=>10,
 "cpu_total_cores"=>20,
 "ems_cluster_id"=>1
 }
```

Storages:
```
{
 "id"=>1,
 "name"=>"NFS Share",
 "location"=>"08e49cea-d9221d10",
 "store_type"=>"NFS",
 "total_space"=>1044536049664,
 "free_space"=>908617875456,
 "uncommitted"=>4650814222336,
 "storage_domain_type"=>nil,
 "host_storages"=>[
   {"ems_ref"=>"datastore-118", "host_id"=>1},
   {"ems_ref"=>"datastore-118", "host_id"=>2},
   {"ems_ref"=>"datastore-118", "host_id"=>3}
 ]
}
```