### PR TITLE
Cache the manifest file to reduce REST API calls

### DIFF
--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -1,5 +1,7 @@
 class Cfme::CloudServices::ManifestFetcher
-  def self.fetch
+  def self.fetch(force: false)
+    raw_manifest_clear_cache if force
+
     manifest = JSON.parse(raw_manifest)
     block_given? ? yield(manifest) : manifest
   end

--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -13,24 +13,26 @@ class Cfme::CloudServices::ManifestFetcher
   end
 
   cache_with_timeout(:raw_manifest) do
-    # TODO: Modeling
-    #   - Should we allow collection of non-model information, such as replication,
-    #     pg_* tables or filesystem level things?
+    begin
+      # TODO: Modeling
+      #   - Should we allow collection of non-model information, such as replication,
+      #     pg_* tables or filesystem level things?
 
-    manifest_config = ::Settings.cfme_cloud_services.manifest_configuration
+      manifest_config = ::Settings.cfme_cloud_services.manifest_configuration
 
-    uri = URI::Generic.build(
-      :scheme => manifest_config.scheme,
-      :host   => manifest_config.host,
-      :port   => manifest_config.port,
-      :path   => File.join(manifest_config.path, Vmdb::Appliance.VERSION)
-    )
+      uri = URI::Generic.build(
+        :scheme => manifest_config.scheme,
+        :host   => manifest_config.host,
+        :port   => manifest_config.port,
+        :path   => File.join(manifest_config.path, Vmdb::Appliance.VERSION)
+      )
 
-    response = RestClient::Resource.new(uri.to_s, certificate_config)
-    response.get
-  rescue StandardError => e
-    _log.error("Error with obtaining manifest with schema: #{e.message}")
-    JSON.generate({})
+      response = RestClient::Resource.new(uri.to_s, certificate_config)
+      response.get
+    rescue StandardError => e
+      _log.error("Error with obtaining manifest with schema: #{e.message}")
+      JSON.generate({})
+    end
   end
   private_class_method :raw_manifest
 end

--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -10,7 +10,7 @@ class Cfme::CloudServices::ManifestFetcher
      :verify_ssl      => OpenSSL::SSL::VERIFY_PEER}
   end
 
-  private_class_method def self.raw_manifest
+  cache_with_timeout(:raw_manifest) do
     # TODO: Modeling
     #   - Should we allow collection of non-model information, such as replication,
     #     pg_* tables or filesystem level things?
@@ -30,4 +30,5 @@ class Cfme::CloudServices::ManifestFetcher
     _log.error("Error with obtaining manifest with schema: #{e.message}")
     JSON.generate({})
   end
+  private_class_method :raw_manifest
 end

--- a/spec/inventory_sync_spec.rb
+++ b/spec/inventory_sync_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe Cfme::CloudServices::InventorySync do
   let(:ems_vmware) { FactoryBot.create(:ems_vmware, :zone => zone) }
   let(:ems_rhv)    { FactoryBot.create(:ems_redhat, :zone => zone) }
 
+  before do
+    allow(Cfme::CloudServices::ManifestFetcher).to receive(:raw_manifest).and_return({"cfme_version" => "5.11.0.0"}.to_json)
+  end
+
   context ".sync" do
     let(:targets) { [[ems_vmware.class.name, ems_vmware.id], "core", [ems_rhv.class.name, ems_rhv.id]] }
 


### PR DESCRIPTION
To reduce the number of times the manifest has to be downloaded from
insights we can cache the manifest file for 5 minutes.