### PR TITLE
Enhancing API to support sync_all and sync_platform

### DIFF
--- a/app/controllers/api/red_hat_cloud_service_providers_controller.rb
+++ b/app/controllers/api/red_hat_cloud_service_providers_controller.rb
@@ -23,10 +23,41 @@ module Api
       action_result(false, e.to_s)
     end
 
+    def sync_collection(type, data)
+      provider_ids = data.fetch("provider_ids")
+      provider_ids = providers_ids.uniq.sort if provider_ids
+      raise BadRequest, "Must specify a list of provider ids via \"provider_ids\"" if provider_ids.empty?
+
+      invalid_provider_ids = find_provider_ids(type) - provider_ids
+      raise BadRequest, "Invalid Provider ids #{invalid_provider_ids.join(', ')} specified" if invalid_provider_ids.present?
+
+      desc = "Syncing Providers ids: #{provider_ids.join(', ')}"
+      task_id = Cfme::CloudServices::InventorySync.sync_queue(User.current_user.userid, providers)
+      action_result(true, desc, :task_id => task_id)
+    rescue => e
+      action_result(false, e.to_s)
+    end
+
+    def sync_all_collection(type, _data)
+      provider_ids = find_provider_ids(type)
+      raise NotFoundError, "There are no Providers to Sync" unless provider_ids.present?
+
+      desc = "Syncing All Providers"
+      task_id = Cfme::CloudServices::InventorySync.sync_queue(User.current_user.userid, provider_ids)
+      action_result(true, desc, :task_id => task_id)
+    rescue => e
+      action_result(false, e.to_s)
+    end
+
     private
 
     def provider_ident(provider)
       "Provider id:#{provider.id} name:'#{provider.name}'"
+    end
+
+    def find_provider_ids(type)
+      providers = collection_search(false, type, collection_class(type))
+      providers ? providers.ids.sort : []
     end
 
     def provider_types

--- a/app/controllers/api/red_hat_cloud_services_controller.rb
+++ b/app/controllers/api/red_hat_cloud_services_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  class RedHatCloudServicesController < BaseController
+    def sync_platform_collection(_type, _data)
+      desc = "Syncing Platform"
+      task_id = Cfme::CloudServices::InventorySync.sync_queue(User.current_user.userid, ["core"])
+      action_result(true, desc, :task_id => task_id)
+    rescue => e
+      action_result(false, e.to_s)
+    end
+  end
+end

--- a/app/javascript/packs/red_hat_cloud_services_list.jsx
+++ b/app/javascript/packs/red_hat_cloud_services_list.jsx
@@ -67,21 +67,23 @@ const RedHatCloudServicesList = () => {
     }
 
     function SyncProviders(selected_providers) {
-      let providers = [];
+      let provider_ids = [];
       selected_providers.forEach( (provider) => {
-        providers.push( { id: provider.id } )
+        provider_ids.push( provider.id )
       });
       API.post('/api/red_hat_cloud_service_providers', {
         action: 'sync',
-        resources: providers,
+        provider_ids: provider_ids,
       }).then(() => dispatch({type: 'setToastVisibility', showToast: true}))
     }
 
     function SyncPlatform() {
-      API.get('/api/red_hat_cloud_service_providers?expand=resources&attributes=id&sort_by=id').then(data => {
-        if (data.resources.length > 0) {
-          SyncProviders(data.resources)
-        }
+      API.post('/api/red_hat_cloud_service_providers', {
+        action: 'sync_all'
+      }).then(() => {
+        API.post('/api/red_hat_cloud_services', {
+          action: 'sync_platform'
+        }).then(() => dispatch({type: 'setToastVisibility', showToast: true}))
       })
     }
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -1,4 +1,15 @@
 :collections:
+  :red_hat_cloud_services:
+    :description: Red Hat Cloud Services
+    :identifier: red_hat_cloud_services
+    :options:
+    - :collection
+    :verbs:
+    - :post
+    :collection_actions:
+      :post:
+      - :name: sync_platform
+        :identifier: red_hat_cloud_services
   :red_hat_cloud_service_providers:
     :description: Red Hat Cloud Service Providers
     :identifier: red_hat_cloud_services
@@ -14,6 +25,8 @@
         :identifier: red_hat_cloud_services
       :post:
       - :name: sync
+        :identifier: red_hat_cloud_services
+      - :name: sync_all
         :identifier: red_hat_cloud_services
     :resource_actions:
       :get:

--- a/spec/requests/red_hat_cloud_services_spec.rb
+++ b/spec/requests/red_hat_cloud_services_spec.rb
@@ -1,0 +1,20 @@
+describe "Red Hat Cloud Services API" do
+  # The following url helper is not defined without GET's on it
+  let(:api_red_hat_cloud_services_url) { "#{api_url}/red_hat_cloud_services" }
+
+  describe "POST" do
+    it "/api/red_hat_cloud_services supports sync_platform action" do
+      api_basic_authorize "red_hat_cloud_services"
+
+      allow(Cfme::CloudServices::InventorySync).to receive("sync_queue").with(@user.userid, ["core"]) { 201 }
+      post(api_red_hat_cloud_services_url, :params => { "action" => "sync_platform" })
+
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => "Syncing Platform",
+        "task_id" => "201"
+      )
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Enhancing the API to support  bulk queueing by leveraging the new API Collection actions and extending the sync action including a new sync_all as well as sync_platform for the "core" (non provider) part of the platform via /api/red_hat_cloud_services

POST /api/red_hat_cloud_service_providers   - action "sync"       with provider_ids specified.
POST /api/red_hat_cloud_service_providers   - action "sync_all"
POST /api/red_hat_cloud_services                   - action "sync_platform"