### PR TITLE
Handle a manifest version in the payload

### DIFF
--- a/app/controllers/api/red_hat_cloud_service_providers_controller.rb
+++ b/app/controllers/api/red_hat_cloud_service_providers_controller.rb
@@ -31,7 +31,7 @@ module Api
 
     def provider_types
       manifest = Cfme::CloudServices::ManifestFetcher.fetch["manifest"] || {}
-      manifest.keys.reject { |k| k == "core" }.uniq
+      manifest.keys.reject { |k| ["core", "version"].include?(k) }.uniq
     end
   end
 end


### PR DESCRIPTION
We need a version on the manifest, this ensures that we do not think
"version" is a type of provider.