### PR TITLE
Add a method to collect and package inventory

### DIFF
--- a/lib/cfme/cloud_services/data_packager.rb
+++ b/lib/cfme/cloud_services/data_packager.rb
@@ -3,7 +3,7 @@ require "tempfile"
 
 class Cfme::CloudServices::DataPackager
   def self.package(payload, tempdir = nil)
-    file = Tempfile.new(["cfme_inventory", ".tar.gz"], tempdir)
+    file = Tempfile.new(["cfme_inventory-", ".tar.gz"], tempdir)
     file.binmode
 
     targz(payload.map(&:to_json), file)

--- a/lib/cfme/cloud_services/data_packager.rb
+++ b/lib/cfme/cloud_services/data_packager.rb
@@ -2,8 +2,8 @@ require "json"
 require "tempfile"
 
 class Cfme::CloudServices::DataPackager
-  def self.package(payload)
-    file = Tempfile.new(["cfme_inventory", ".tar.gz"])
+  def self.package(payload, tempdir = nil)
+    file = Tempfile.new(["cfme_inventory", ".tar.gz"], tempdir)
     file.binmode
 
     targz(payload.map(&:to_json), file)

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -31,9 +31,7 @@ module Cfme
 
       def self.collect(opts)
         path = DataPackager.package(DataCollector.collect(opts[:manifest], targets_from_queue(opts[:targets])))
-
-        MiqTask.find(opts[:task_id]).update_attributes!(:context_data => {:path => path.to_s}) if opts[:task_id]
-
+        update_task(opts[:task_id], path.to_s) if opts[:task_id]
         path
       end
 
@@ -77,6 +75,13 @@ module Cfme
         targets.map do |klass_or_instance, id|
           id.nil? ? klass_or_instance : klass_or_instance.to_s.constantize.find(id)
         end
+      end
+
+      private_class_method def self.update_task(task_id, path)
+        task = MiqTask.find(task_id)
+        task.context_data ||= {}
+        task.context_data.merge!({:payload_path => path})
+        task.save!
       end
     end
   end

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -29,13 +29,13 @@ module Cfme
         MiqTask.generic_action_with_callback(task_opts, queue_opts)
       end
 
-      def self.collect(manifest:, targets:, task_id: nil, miq_task_id: nil)
-        path = DataPackager.package(DataCollector.collect(manifest, targets_from_queue(targets)))
+      def self.collect(manifest:, targets:, tempdir: nil, task_id: nil, miq_task_id: nil)
+        path = DataPackager.package(DataCollector.collect(manifest, targets_from_queue(targets)), tempdir)
         update_task(task_id, path.to_s) if task_id
         path
       end
 
-      def self.collect_queue(userid, manifest, targets)
+      def self.collect_queue(userid, manifest, targets, tempdir = nil)
         task_opts = {
           :action => "Collect and package inventory",
           :userid => userid
@@ -44,7 +44,7 @@ module Cfme
         queue_opts = {
           :class_name  => name,
           :method_name => "collect",
-          :args        => [{:manifest => manifest, :targets => targets_for_queue(targets)}]
+          :args        => [{:manifest => manifest, :targets => targets_for_queue(targets), :tempdir => tempdir}]
         }
 
         MiqTask.generic_action_with_callback(task_opts, queue_opts)

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -29,13 +29,13 @@ module Cfme
         MiqTask.generic_action_with_callback(task_opts, queue_opts)
       end
 
-      def self.collect(manifest:, targets:, tempdir: nil, task_id: nil, miq_task_id: nil)
+      def self.bundle(manifest:, targets:, tempdir: nil, task_id: nil, miq_task_id: nil)
         path = DataPackager.package(DataCollector.collect(manifest, targets_from_queue(targets)), tempdir)
         update_task(task_id, path.to_s) if task_id
         path
       end
 
-      def self.collect_queue(userid, manifest, targets, tempdir = nil)
+      def self.bundle_queue(userid, manifest, targets, tempdir = nil)
         task_opts = {
           :action => "Collect and package inventory",
           :userid => userid
@@ -43,7 +43,7 @@ module Cfme
 
         queue_opts = {
           :class_name  => name,
-          :method_name => "collect",
+          :method_name => "bundle",
           :args        => [{:manifest => manifest, :targets => targets_for_queue(targets), :tempdir => tempdir}]
         }
 

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -42,9 +42,9 @@ module Cfme
         }
 
         queue_opts = {
-          :class_name  => self.name,
+          :class_name  => name,
           :method_name => "collect",
-          :args        => [{manifest: manifest, targets: targets_for_queue(targets)}]
+          :args        => [{:manifest => manifest, :targets => targets_for_queue(targets)}]
         }
 
         MiqTask.generic_action_with_callback(task_opts, queue_opts)

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -80,7 +80,7 @@ module Cfme
       private_class_method def self.update_task(task_id, path)
         task = MiqTask.find(task_id)
         task.context_data ||= {}
-        task.context_data.merge!({:payload_path => path})
+        task.context_data[:payload_path] = path
         task.save!
       end
     end

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -29,9 +29,9 @@ module Cfme
         MiqTask.generic_action_with_callback(task_opts, queue_opts)
       end
 
-      def self.collect(opts)
-        path = DataPackager.package(DataCollector.collect(opts[:manifest], targets_from_queue(opts[:targets])))
-        update_task(opts[:task_id], path.to_s) if opts[:task_id]
+      def self.collect(manifest:, targets:, task_id: nil, miq_task_id: nil)
+        path = DataPackager.package(DataCollector.collect(manifest, targets_from_queue(targets)))
+        update_task(task_id, path.to_s) if task_id
         path
       end
 

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -29,6 +29,29 @@ module Cfme
         MiqTask.generic_action_with_callback(task_opts, queue_opts)
       end
 
+      def self.collect(opts)
+        path = DataPackager.package(DataCollector.collect(opts[:manifest], targets_from_queue(opts[:targets])))
+
+        MiqTask.find(opts[:task_id]).update_attributes!(:context_data => {:path => path.to_s}) if opts[:task_id]
+
+        path
+      end
+
+      def self.collect_queue(userid, manifest, targets)
+        task_opts = {
+          :action => "Collect and package inventory",
+          :userid => userid
+        }
+
+        queue_opts = {
+          :class_name  => self.name,
+          :method_name => "collect",
+          :args        => [{manifest: manifest, targets: targets_for_queue(targets)}]
+        }
+
+        MiqTask.generic_action_with_callback(task_opts, queue_opts)
+      end
+
       private_class_method def self.targets_for_queue(targets)
         # Handle someone passing in a single instance, an array of instances,
         # an array of [class_name, id] pairs, or a mixture of instances and


### PR DESCRIPTION
Adds a top-level method to collect and package inventory as well as a
_queue method which returns a task for the API to call.

This is useful if the manifest can't be fetched from the API and when
the payload can't be posted directly to insights via the
insights-client.