### PR TITLE
Show Active menu items correctly

### DIFF
--- a/app/controllers/red_hat_cloud_services_controller.rb
+++ b/app/controllers/red_hat_cloud_services_controller.rb
@@ -3,7 +3,7 @@ class RedHatCloudServicesController < ApplicationController
   after_action :cleanup_action
 
   def show_list
-    @layout = 'red_hat_cloud_services'
+    @layout = 'red_hat_cloud_services_providers'
     @page_title = _('Red Hat Cloud Services')
     render :show_list
   end

--- a/lib/cfme/cloud_services/engine.rb
+++ b/lib/cfme/cloud_services/engine.rb
@@ -16,8 +16,8 @@ module Cfme
       initializer 'plugin' do
         Menu::CustomLoader.register(
           Menu::Section.new(:red_hat_cloud_services, N_("Red Hat Cloud"), 'pficon ff ff-red-hat-logo', [
-           Menu::Item.new('services', N_('Services'), 'red_hat_cloud_services', {:feature => 'red_hat_cloud_services', :any => true}, '/red_hat_cloud_services/show'),
-           Menu::Item.new('services', N_('Providers'), 'red_hat_cloud_services', {:feature => 'red_hat_cloud_services', :any => true}, '/red_hat_cloud_services/show_list')
+            Menu::Item.new('red_hat_cloud_services', N_('Services'), 'red_hat_cloud_services', {:feature => 'red_hat_cloud_services', :any => true}, '/red_hat_cloud_services/show'),
+            Menu::Item.new('red_hat_cloud_services_providers', N_('Providers'), 'red_hat_cloud_services_providers', {:feature => 'red_hat_cloud_services', :any => true}, '/red_hat_cloud_services/show_list')
          ])
         )
       end


### PR DESCRIPTION
There is an issue when user select Menu Item under `Services` items under `Red Hat Cloud  Services` also get selected. It was caused by using same id `services` for menu items.

https://bugzilla.redhat.com/show_bug.cgi?id=1733489