### PR TITLE
Allow settings to override the verify_ssl param

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 ---
 :cfme_cloud_services:
   :manifest_configuration:
+    :verify_ssl: true
     :scheme: https
     :host: cert.cloud.redhat.com
     :port:

--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -6,28 +6,31 @@ class Cfme::CloudServices::ManifestFetcher
     block_given? ? yield(manifest) : manifest
   end
 
-  private_class_method def self.certificate_config
+  private_class_method def self.manifest_configuration
+    ::Settings.cfme_cloud_services.manifest_configuration
+  end
+
+  private_class_method def self.certificate_options
     {:ssl_client_cert => OpenSSL::X509::Certificate.new(File.read("/etc/pki/consumer/cert.pem")),
-     :ssl_client_key  => OpenSSL::PKey::RSA.new(File.read("/etc/pki/consumer/key.pem")),
-     :verify_ssl      => OpenSSL::SSL::VERIFY_PEER}
+     :ssl_client_key  => OpenSSL::PKey::RSA.new(File.read("/etc/pki/consumer/key.pem"))}
+  end
+
+  private_class_method def self.ssl_options
+    {:verify_ssl => manifest_configuration.verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE}
   end
 
   cache_with_timeout(:raw_manifest) do
     begin
-      # TODO: Modeling
-      #   - Should we allow collection of non-model information, such as replication,
-      #     pg_* tables or filesystem level things?
-
-      manifest_config = ::Settings.cfme_cloud_services.manifest_configuration
-
       uri = URI::Generic.build(
-        :scheme => manifest_config.scheme,
-        :host   => manifest_config.host,
-        :port   => manifest_config.port,
-        :path   => File.join(manifest_config.path, Vmdb::Appliance.VERSION)
+        :scheme => manifest_configuration.scheme,
+        :host   => manifest_configuration.host,
+        :port   => manifest_configuration.port,
+        :path   => File.join(manifest_configuration.path, Vmdb::Appliance.VERSION)
       )
 
-      response = RestClient::Resource.new(uri.to_s, certificate_config)
+      options = certificate_options.merge(ssl_options)
+
+      response = RestClient::Resource.new(uri.to_s, options)
       response.get
     rescue StandardError => e
       _log.error("Error with obtaining manifest with schema: #{e.message}")

--- a/spec/manifest_fetcher_spec.rb
+++ b/spec/manifest_fetcher_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe Cfme::CloudServices::ManifestFetcher do
 
     let(:certificate) do
       {:ssl_client_cert => cert.to_pem,
-       :ssl_client_key  => key,
-       :verify_ssl      => OpenSSL::SSL::VERIFY_PEER}
+       :ssl_client_key  => key}
     end
 
     it "fetches manifest" do
@@ -55,11 +54,11 @@ RSpec.describe Cfme::CloudServices::ManifestFetcher do
         :path   => File.join(uri_config.path, Vmdb::Appliance.VERSION)
       )
 
-      allow(described_class).to receive(:certificate_config).and_return(certificate)
+      allow(described_class).to receive(:certificate_options).and_return(certificate)
 
       require 'rest-client'
 
-      expect(RestClient::Resource).to receive(:new).with(uri.to_s, certificate).and_return(RestClient::Resource.new(nil))
+      expect(RestClient::Resource).to receive(:new).with(uri.to_s, a_hash_including(certificate)).and_return(RestClient::Resource.new(nil))
       allow_any_instance_of(RestClient::Resource).to receive(:get).and_return(manifest_response)
 
       expect(described_class.send(:fetch)).to eq(expected_json_manifest)


### PR DESCRIPTION
When downloading the manifest from insights-ci we need to not verify
ssl.