### PR TITLE
added data_collected_on to payload

### DIFF
--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -19,9 +19,10 @@ class Cfme::CloudServices::DataCollector
 
   def payload_hash
     {
-      "cfme_version" => cfme_version,
-      "schema"       => {"name" => "Cfme"},
-      "manifest"     => manifest,
+      "cfme_version"      => cfme_version,
+      "data_collected_on" => Time.now,
+      "schema"            => {"name" => "Cfme"},
+      "manifest"          => manifest,
     }
   end
 

--- a/lib/cfme/cloud_services/data_collector.rb
+++ b/lib/cfme/cloud_services/data_collector.rb
@@ -20,7 +20,7 @@ class Cfme::CloudServices::DataCollector
   def payload_hash
     {
       "cfme_version"      => cfme_version,
-      "data_collected_on" => Time.now,
+      "data_collected_on" => Time.now.utc,
       "schema"            => {"name" => "Cfme"},
       "manifest"          => manifest,
     }


### PR DESCRIPTION
Added a `data_collected_on` timestamp to the top of the payload so that applications can track the age and deltas from multiple uploads.