### PR TITLE
Raise error when there is issue on endpoint in ManifestFest

### DIFF
--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -34,7 +34,7 @@ class Cfme::CloudServices::ManifestFetcher
       response.get
     rescue StandardError => e
       _log.error("Error with obtaining manifest with schema: #{e.message}")
-      JSON.generate({})
+      raise
     end
   end
   private_class_method :raw_manifest

--- a/spec/manifest_fetcher_spec.rb
+++ b/spec/manifest_fetcher_spec.rb
@@ -63,5 +63,21 @@ RSpec.describe Cfme::CloudServices::ManifestFetcher do
 
       expect(described_class.send(:fetch)).to eq(expected_json_manifest)
     end
+
+    let(:fake_configuration) do
+      {
+        :scheme => "https",
+        :host   => "fakeXXXX.XXXX",
+        :path   => "/api"
+      }
+    end
+
+    it 'raises error when there is issue on endpoint' do
+      require 'rest-client'
+      allow(::Settings.cfme_cloud_services).to receive(:manifest_configuration).and_return(OpenStruct.new(fake_configuration))
+      allow(described_class).to receive(:certificate_options).and_return(certificate)
+
+      expect { described_class.send(:raw_manifest) }.to raise_error StandardError
+    end
   end
 end


### PR DESCRIPTION

the other benefit is that it will not continue with sending empty inventory to cloud (I guess this is not needed) on errors with obtaining manifest.



@miq-bot assign @agrare 