### PR TITLE
Filter out password fields from the manifest

### DIFF
--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -2,7 +2,7 @@ class Cfme::CloudServices::ManifestFetcher
   def self.fetch(force: false)
     raw_manifest_clear_cache if force
 
-    manifest = JSON.parse(raw_manifest)
+    manifest = Vmdb::Settings.filter_passwords!(JSON.parse(raw_manifest))
     block_given? ? yield(manifest) : manifest
   end
 


### PR DESCRIPTION
Use Vmdb::Settings.filter_passwords! to filter out any password
properties from the manifest.

https://github.com/ManageIQ/manageiq/pull/19144