### PR TITLE
Fix an integer overflow error for large files

### DIFF
--- a/lib/cfme/cloud_services/data_packager.rb
+++ b/lib/cfme/cloud_services/data_packager.rb
@@ -25,7 +25,7 @@ class Cfme::CloudServices::DataPackager
     Zlib::GzipWriter.wrap(io) do |gz|
       Gem::Package::TarWriter.new(gz) do |tar|
         files.each_with_index do |file, i|
-          tar.add_file_simple("cfme_inventory_#{i}.json", 0o0444, file.length) do |tar_file|
+          tar.add_file_simple("cfme_inventory_#{i}.json", 0o0444, file.bytesize) do |tar_file|
             tar_file.write(file)
           end
         end


### PR DESCRIPTION
Large files cause `"You tried to feed more data than fits in the file."`
error from Rubygems tar file writer.  The solution is to pass bytesize
instead of length to add_file_simple.

Note: I didn't observe this on a GNU/Linux machine but it was seen on a
Mac with a 10KiB resulting tgz file.  I'm guessing there is a difference
in byte size between int, long, and long long on the different systems.