### PR TITLE
Allow file permissions to be set by caller

### DIFF
--- a/lib/cfme/cloud_services/data_packager.rb
+++ b/lib/cfme/cloud_services/data_packager.rb
@@ -2,15 +2,17 @@ require "json"
 require "tempfile"
 
 class Cfme::CloudServices::DataPackager
-  def self.package(payload, tempdir = nil)
-    file = Tempfile.new(["cfme_inventory-", ".tar.gz"], tempdir)
+  def self.package(payload, tempdir = nil, perm = nil)
+    file = Tempfile.create(["cfme_inventory-", ".tar.gz"], tempdir)
     file.binmode
 
     targz(payload.map(&:to_json), file)
 
-    file.close(false)
+    file.close
 
     path = Pathname.new(file.path)
+    FileUtils.chmod(perm, [path]) if perm
+
     return path unless block_given?
 
     begin

--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -29,22 +29,24 @@ module Cfme
         MiqTask.generic_action_with_callback(task_opts, queue_opts)
       end
 
-      def self.bundle(manifest:, targets:, tempdir: nil, task_id: nil, miq_task_id: nil)
-        path = DataPackager.package(DataCollector.collect(manifest, targets_from_queue(targets)), tempdir)
+      def self.bundle(manifest:, targets:, tempdir: nil, perm: nil, task_id: nil, miq_task_id: nil)
+        path = DataPackager.package(DataCollector.collect(manifest, targets_from_queue(targets)), tempdir, perm)
         update_task(task_id, path.to_s) if task_id
         path
       end
 
-      def self.bundle_queue(userid, manifest, targets, tempdir = nil)
+      def self.bundle_queue(userid, manifest, targets, tempdir = nil, perm = nil)
         task_opts = {
           :action => "Collect and package inventory",
           :userid => userid
         }
 
+        args = {:manifest => manifest, :targets => targets_for_queue(targets), :tempdir => tempdir, :perm => perm}
+
         queue_opts = {
           :class_name  => name,
           :method_name => "bundle",
-          :args        => [{:manifest => manifest, :targets => targets_for_queue(targets), :tempdir => tempdir}]
+          :args        => [args]
         }
 
         MiqTask.generic_action_with_callback(task_opts, queue_opts)


### PR DESCRIPTION
The file that gets created by Tempfile always has access mode 0600 and
cannot be overridden by the caller.  This isn't always ideal so provide
an option to the caller of modifying the access mode after the file is
created.