### PR TITLE
Add ip address to context data

### DIFF
--- a/lib/cfme/cloud_services/inventory_sync.rb
+++ b/lib/cfme/cloud_services/inventory_sync.rb
@@ -83,6 +83,7 @@ module Cfme
         task = MiqTask.find(task_id)
         task.context_data ||= {}
         task.context_data[:payload_path] = path
+        task.context_data[:ip_address] = MiqServer.my_server.ipaddress
         task.save!
       end
     end


### PR DESCRIPTION
This is to send back IP address of the appliance, where the actual payload is stored / saved.

Sample task result when sent over API:
```
{
    "href": "http://localhost:3000/api/tasks/350",
    "id": "350",
    "name": "Collect and package inventory",
    "state": "Finished",
    "status": "Ok",
    "message": "Task completed successfully",
    "userid": "admin",
    "created_on": "2019-08-22T13:50:05Z",
    "updated_on": "2019-08-22T13:50:07Z",
    "pct_complete": null,
    "context_data": {
        "payload_path": "/tmp/cfme_inventory-20190822-30550-1ufxu0p.tar.gz",
        "ip_address": "192.168.1.17"
    },
    "results": null,
    "miq_server_id": "3",
    "identifier": null,
    "started_on": "2019-08-22T13:50:06Z",
    "zone": null,
    "actions": [
        {
            "name": "delete",
            "method": "post",
            "href": "http://localhost:3000/api/tasks/350"
        },
        {
            "name": "delete",
            "method": "delete",
            "href": "http://localhost:3000/api/tasks/350"
        }
    ]
}
```

@agrare review please? Thank you.