### PR TITLE
Fix sync_all_collection and sync_collection

### DIFF
--- a/app/controllers/api/red_hat_cloud_service_providers_controller.rb
+++ b/app/controllers/api/red_hat_cloud_service_providers_controller.rb
@@ -24,8 +24,8 @@ module Api
     end
 
     def sync_collection(type, data)
-      provider_ids = data["provider_ids"].map(&:to_i)
-      provider_ids = provider_ids.uniq if provider_ids
+      provider_ids = data["provider_ids"]
+      provider_ids = provider_ids.map(&:to_i).uniq if provider_ids
       raise "Must specify a list of provider ids via \"provider_ids\"" if provider_ids.blank?
 
       invalid_provider_ids = provider_ids - find_provider_ids(type)

--- a/spec/requests/red_hat_cloud_service_providers_spec.rb
+++ b/spec/requests/red_hat_cloud_service_providers_spec.rb
@@ -126,7 +126,7 @@ describe "Red Hat Cloud Service Providers API" do
       post(api_red_hat_cloud_service_providers_url,
            :params => {
              "action"       => "sync",
-             "provider_ids" => [9999, ems1.id, ems2.id, 8888]
+             "provider_ids" => ["9999", ems1.id.to_s, ems2.id.to_s, "8888"]
            })
 
       expect(response.parsed_body).to include(
@@ -142,12 +142,13 @@ describe "Red Hat Cloud Service Providers API" do
       ems1 = FactoryBot.create(:ems_vmware, :name => "sample vmware1")
       ems2 = FactoryBot.create(:ems_vmware, :name => "sample vmware2")
 
-      allow(Cfme::CloudServices::InventorySync).to receive("sync_queue").with(@user.userid, [ems1.id, ems2.id]) { 104 }
+      allow(Cfme::CloudServices::InventorySync).to receive("sync_queue")
+        .with(@user.userid, [["ExtManagementSystem", ems1.id], ["ExtManagementSystem", ems2.id]]) { 104 }
 
       post(api_red_hat_cloud_service_providers_url,
            :params => {
              "action"       => "sync",
-             "provider_ids" => [ems1.id, ems2.id]
+             "provider_ids" => [ems1.id.to_s, ems2.id.to_s]
            })
 
       expect(response.parsed_body).to include(
@@ -179,9 +180,8 @@ describe "Red Hat Cloud Service Providers API" do
       ems1 = FactoryBot.create(:ems_vmware, :name => "sample vmware1")
       ems2 = FactoryBot.create(:ems_vmware, :name => "sample vmware2")
 
-      ems_ids = [ems1.id, ems2.id].sort
-
-      allow(Cfme::CloudServices::InventorySync).to receive("sync_queue").with(@user.userid, ems_ids) { 105 }
+      allow(Cfme::CloudServices::InventorySync).to receive("sync_queue")
+        .with(@user.userid, [["ExtManagementSystem", ems1.id], ["ExtManagementSystem", ems2.id]]) { 105 }
 
       post(api_red_hat_cloud_service_providers_url,
            :params => {


### PR DESCRIPTION
Fix two issues with syncing multiple providers.

1. Targets must be of form `[[klass, id]]` not `[id]`

Fix invalid targets being passed to `InventorySync.sync`, targets must either be an `ActiveRecord` object or a `[klass, id]` pair.  This was passing just id.

2. Fix comparison of strings with integers

`data["provider_ids"]` looks like `["1", "2"]` but `find_provider_ids` looks like `[1, 2]` so every provider id looks invalid.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1751877