### PR TITLE
Better message when certificates are missing in ManifestFetcher

### DIFF
--- a/lib/cfme/cloud_services/manifest_fetcher.rb
+++ b/lib/cfme/cloud_services/manifest_fetcher.rb
@@ -11,8 +11,16 @@ class Cfme::CloudServices::ManifestFetcher
   end
 
   private_class_method def self.certificate_options
-    {:ssl_client_cert => OpenSSL::X509::Certificate.new(File.read("/etc/pki/consumer/cert.pem")),
-     :ssl_client_key  => OpenSSL::PKey::RSA.new(File.read("/etc/pki/consumer/key.pem"))}
+    certificate_file = "/etc/pki/consumer/cert.pem"
+
+    subscription_manager_message = _("Check whether subscription manager is configured properly.")
+    raise _("Unable to find certificate file:") + " #{certificate_file}. #{subscription_manager_message}" unless File.file?(certificate_file)
+
+    key_file = "/etc/pki/consumer/key.pem"
+    raise _("Unable to find key file:") + " #{key_file}. #{subscription_manager_message}." unless File.file?(key_file)
+
+    {:ssl_client_cert => OpenSSL::X509::Certificate.new(File.read(certificate_file)),
+     :ssl_client_key  => OpenSSL::PKey::RSA.new(File.read(key_file))}
   end
 
   private_class_method def self.ssl_options


### PR DESCRIPTION
now:
this error message is displayed here.

![Screenshot 2019-09-18 at 15 28 24](https://user-images.githubusercontent.com/14937244/65152818-fc6c1700-da28-11e9-9447-1d6713471684.png)

but I believe that @PanSpagetka can just display the error message in dialog nicely.


# Links

https://bugzilla.redhat.com/show_bug.cgi?id=1740133


@miq-bot assign @agrare 

