### PR TITLE
Log failure(by setting exit_code=1) when insights_client fails with exit_code=0

### DIFF
--- a/lib/cfme/cloud_services/data_uploader.rb
+++ b/lib/cfme/cloud_services/data_uploader.rb
@@ -6,6 +6,8 @@ class Cfme::CloudServices::DataUploader
 
     params = {:payload= => path, :content_type= => "application/vnd.redhat.topological-inventory.something+tgz"}
     result = AwesomeSpawn.run("insights-client", :params => params)
+    result.exit_status = 1 if result.error.present?
+
     if result.failure?
       _log.error("Uploading #{path} to cloud.redhat.com...Failure - #{result.output} #{result.error}")
     else

--- a/spec/data_uploader_spec.rb
+++ b/spec/data_uploader_spec.rb
@@ -8,5 +8,25 @@ RSpec.describe Cfme::CloudServices::DataUploader do
 
       described_class.upload(path)
     end
+
+    let(:failure_output) do
+      'Uploading Insights data.' \
+      'Upload attempt 1 of 1 failed! Status code: 401' \
+      'All attempts to upload have failed!' \
+      'Please see /var/log/insights-client/insights-client.log for additional information'
+    end
+
+    let(:failure_command_result) do
+      AwesomeSpawn::CommandResult.new("", "", failure_output, 0)
+    end
+
+    it "returns false when insights-client returns failure output with exit code 0" do
+      path = "/tmp/cfme_upload.tar.gz"
+      expected_params = {:payload= => path, :content_type= => "application/vnd.redhat.topological-inventory.something+tgz"}
+
+      expect(AwesomeSpawn).to receive(:run).with("insights-client", :params => expected_params).and_return(failure_command_result)
+
+      expect(described_class.upload(path)).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
According to my testing,`insights_client` sends error output to standard error output on failure but `insights_client` as command has exit code 0 .

<img width="1678" alt="Screenshot 2019-09-23 at 12 51 54" src="https://user-images.githubusercontent.com/14937244/65420244-f0a19b80-de00-11e9-8288-49a6c53e3fb1.png">

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1747178

@miq-bot assign @agrare 
