### PR TITLE
Test with ruby 2.5.7 and 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: xenial
 language: ruby
 cache: bundler
 rvm:
-- 2.4.5
-- 2.5.3
+- 2.5.7
+- 2.6.5
 env:
   global:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000


### PR DESCRIPTION
Now that master only supports ruby 2.5+ disable testing with ruby 2.4

https://travis-ci.org/RedHatCloudForms/cfme-cloud_services/jobs/605717567